### PR TITLE
Remove Dark Loader Screen conflict

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,8 +25,5 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "minecraft": "1.16.5"
-  },
-  "conflicts": {
-    "dark-loading-screen": "*"
   }
 }


### PR DESCRIPTION
It's a bit :concern: that it allowed me to even load both of these mods despite it being in the conflicts, yet still, behold:
![magic](https://i.imgur.com/zzlUa5U.png)