### PR TITLE
Update to 1.20.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,22 @@
 [versions]
-minecraft = '1.20.1'
+minecraft = '1.20.2'
 
 [libraries]
 # https://lambdaurora.dev/tools/import_quilt.html
 minecraft = { module = 'com.mojang:minecraft', version.ref = 'minecraft' }
-quilt_mappings = 'org.quiltmc:quilt-mappings:1.20.1+build.9'
-quilt_loader = 'org.quiltmc:quilt-loader:0.19.2'
-quilted_fabric_api = 'org.quiltmc.quilted-fabric-api:quilted-fabric-api:7.0.5+0.84.0-1.20.1'
+quilt_mappings = 'org.quiltmc:quilt-mappings:1.20.2+build.3'
+quilt_loader = 'org.quiltmc:quilt-loader:0.23.1'
+quilted_fabric_api = 'org.quiltmc.quilted-fabric-api:quilted-fabric-api:8.0.0-alpha.3+0.91.2-1.20.2'
 
-midnightlib = 'maven.modrinth:midnightlib:1.4.1-fabric'
+midnightlib = 'maven.modrinth:midnightlib:1.5.0-fabric'
 
-mod_menu = 'maven.modrinth:modmenu:7.1.0'
+mod_menu = 'maven.modrinth:modmenu:8.0.1'
 
 [bundles]
 quilt = ['quilt_loader', 'quilted_fabric_api']
 
 [plugins]
-quilt_loom = 'org.quiltmc.loom:1.1.+'
+quilt_loom = 'org.quiltmc.loom:1.4.+'
 quilt_licenser = 'org.quiltmc.gradle.licenser:1.+'
 minotaur = 'com.modrinth.minotaur:2.+'
 machete = 'io.github.p03w.machete:2.+'

--- a/src/main/java/com/emmacypress/quilt_loading_screen/QLSClientInit.java
+++ b/src/main/java/com/emmacypress/quilt_loading_screen/QLSClientInit.java
@@ -13,7 +13,7 @@ import net.minecraft.client.util.ColorUtil;
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.qsl.base.api.entrypoint.client.ClientModInitializer;
 import org.quiltmc.qsl.resource.loader.api.ResourceLoader;
-import org.quiltmc.qsl.resource.loader.api.ResourcePackActivationType;
+import org.quiltmc.qsl.resource.loader.api.PackActivationType;
 
 import static com.emmacypress.quilt_loading_screen.QuiltLoadingScreen.MODID;
 import static com.emmacypress.quilt_loading_screen.QuiltLoadingScreen.id;
@@ -26,7 +26,7 @@ public class QLSClientInit implements ClientModInitializer {
 	public void onInitializeClient(ModContainer mod) {
 		MidnightConfig.init(MODID, Config.class);
 
-		ResourceLoader.registerBuiltinResourcePack(id("quilt-ui"), mod, ResourcePackActivationType.NORMAL);
+		ResourceLoader.registerBuiltinPack(id("quilt-ui"), mod, PackActivationType.NORMAL);
 
 		if (Config.modifyBackgroundColor)
 			SplashOverlayAccessor.setMojangRed(ColorUtil.ARGB32.getArgb(0, 35, 22, 56));


### PR DESCRIPTION
Title says it all.

QSL 8.+ changed a few names around in regards to resource loading, and that prevented QLoadingScreen 6.0.0+1.20.1 from running on Minecraft 1.20.2.